### PR TITLE
Fix for issue #25 - Add support for branches with '/' in them

### DIFF
--- a/src/app-helpers.js
+++ b/src/app-helpers.js
@@ -128,7 +128,7 @@ export function useLanguageLoader(path) {
 }
 
 export function useCommitsFetcher({ repo, path }) {
-  return useLoader(async () => getCommits(repo,  path), [repo, path]);
+  return useLoader(async () => getCommits(repo, path), [repo, path]);
 }
 
 export function useDocumentTitle(title) {
@@ -138,19 +138,15 @@ export function useDocumentTitle(title) {
 }
 
 export function getUrlParams() {
-  const [
-    ,
-    owner,
-    reponame,
-    action,
-    ...paths
-  ] = window.location.pathname.split("/");
+  const [, owner, reponame, action, ...paths] = window.location.pathname.split(
+    "/"
+  );
 
   if (action !== "commits" && action !== "blob") {
     return [];
   }
 
-  return [owner + "/" + reponame,  "/" + paths.join("/")];
+  return [owner + "/" + reponame, "/" + paths.join("/")];
 }
 
 function login() {

--- a/src/app-helpers.js
+++ b/src/app-helpers.js
@@ -127,8 +127,8 @@ export function useLanguageLoader(path) {
   }, [path]);
 }
 
-export function useCommitsFetcher({ repo, sha, path }) {
-  return useLoader(async () => getCommits(repo, sha, path), [repo, sha, path]);
+export function useCommitsFetcher({ repo, path }) {
+  return useLoader(async () => getCommits(repo,  path), [repo, path]);
 }
 
 export function useDocumentTitle(title) {
@@ -143,7 +143,6 @@ export function getUrlParams() {
     owner,
     reponame,
     action,
-    sha,
     ...paths
   ] = window.location.pathname.split("/");
 
@@ -151,7 +150,7 @@ export function getUrlParams() {
     return [];
   }
 
-  return [owner + "/" + reponame, sha, "/" + paths.join("/")];
+  return [owner + "/" + reponame,  "/" + paths.join("/")];
 }
 
 function login() {

--- a/src/app.js
+++ b/src/app.js
@@ -17,12 +17,12 @@ export default function App() {
     return <CliApp data={cli} />;
   }
 
-  const [repo, sha, path] = getUrlParams();
+  const [repo, path] = getUrlParams();
 
   if (!repo) {
     return <Landing />;
   } else {
-    return <GitHubApp repo={repo} sha={sha} path={path} />;
+    return <GitHubApp repo={repo} path={path} />;
   }
 }
 

--- a/src/github.js
+++ b/src/github.js
@@ -31,27 +31,29 @@ async function splitBranchAndFilePath(repo, path) {
     { headers: getHeaders() }
   );
 
-  const branchesJson = await branchesResponse.json()
-  const branchNames = branchesJson.map(branch => branch.name).sort(function(a, b) {
-    // Sort by length so that the longest string is always tried first. 
-    // That way we won't remove any substrings by accident.
-    return b.length - a.length;
-  })
+  const branchesJson = await branchesResponse.json();
+  const branchNames = branchesJson
+    .map(branch => branch.name)
+    .sort(function(a, b) {
+      // Sort by length so that the longest string is always tried first.
+      // That way we won't remove any substrings by accident.
+      return b.length - a.length;
+    });
 
   let branchName = "master";
-  let filePath = path
+  let filePath = path;
   branchNames.forEach(branch => {
-    if(path.startsWith("/" + branch)) {
-      branchName = branch
-      filePath = path.replace("/" + branch + "/", "")
+    if (path.startsWith("/" + branch)) {
+      branchName = branch;
+      filePath = path.replace("/" + branch + "/", "");
     }
-  })
-  return {branchName, filePath}
+  });
+  return { branchName, filePath };
 }
 
 export async function getCommits(repo, path, top = 10) {
-  const {branchName, filePath} = await splitBranchAndFilePath(repo, path)
-  
+  const { branchName, filePath } = await splitBranchAndFilePath(repo, path);
+
   const commitsResponse = await fetch(
     `https://api.github.com/repos/${repo}/commits?sha=${branchName}&path=${filePath}`,
     { headers: getHeaders() }
@@ -60,7 +62,6 @@ export async function getCommits(repo, path, top = 10) {
     throw commitsResponse;
   }
   const commitsJson = await commitsResponse.json();
-
 
   const commits = commitsJson
     .slice(0, top)


### PR DESCRIPTION
This pull request updates `github.js` to use the branches API to split the filepath from the branch path and use them both accordingly in calls to `/contents` and `/commits`. This means we don't have to naively try and pull the `sha` variable from the path anymore.