### PR TITLE
bug fix: scrolling on CommitList scrolls the page as well

### DIFF
--- a/src/history.js
+++ b/src/history.js
@@ -68,6 +68,7 @@ function CommitInfo({ commit, move, onClick }) {
 
 function CommitList({ commits, currentIndex, selectCommit }) {
   const mouseWheelEvent = e => {
+    e.preventDefault();
     selectCommit(currentIndex + (e.deltaX + e.deltaY) / 100);
   };
   return (


### PR DESCRIPTION
This is an awesome project and a nice way to learn about the new react hooks. Thanks!

### before:

![before](https://user-images.githubusercontent.com/22118580/52726058-13421b00-2fbb-11e9-9283-7ae67e0fe95a.gif)

### after:

![after](https://user-images.githubusercontent.com/22118580/52726073-1a692900-2fbb-11e9-998c-d7561c225126.gif)
