### PR TITLE
Add option to allow turn --follow on/off

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -4,21 +4,33 @@ const runServer = require("./server");
 const getCommits = require("./git");
 const fs = require("fs");
 
-const path = process.argv[2];
+const argvs = process.argv.slice(2);
 
-if (!path || path === "--help") {
+const options = {
+  follow: false,
+};
+
+if (argvs.length === 0 || argvs.indexOf('--help') !== -1) {
   console.log(`Usage:
+  Options:
+    --follow    Work as git log --follow.
 
   githistory some/file.ext
   `);
   process.exit();
 }
 
-if (!fs.existsSync(path)) {
+if (argvs.indexOf('--follow') !== -1) {
+  options.follow = true;
+} 
+
+const path = argvs[argvs.length - 1];
+
+if (!path || !fs.existsSync(path)) {
   console.log(`File not found: ${path}`);
   process.exit();
 }
 
-const commitsPromise = getCommits(path);
+const commitsPromise = getCommits(path, options);
 
 runServer(path, commitsPromise);


### PR DESCRIPTION
To fix 
[[CLI] Only display part of git history](https://github.com/pomber/git-history/issues/81)
by allow user turn --follow on/off.