### PR TITLE
fix(style): comment box arrow position

### DIFF
--- a/src/comment-box.css
+++ b/src/comment-box.css
@@ -21,12 +21,13 @@
 .comment-box:after {
   border-color: rgba(1, 22, 39, 0);
   border-bottom-color: rgb(1, 22, 39);
-  border-width: 11px;
-  margin-left: -11px;
+  border-width: 13px;
+  margin-left: -13px;
 }
 .comment-box:before {
   border-color: rgba(1, 22, 39, 0);
   border-bottom-color: rgb(214, 222, 235, 0.5);
   border-width: 14px;
   margin-left: -14px;
+  margin-bottom: 2px;
 }


### PR DESCRIPTION
Hi, @pomber 
Thank you for git-history - its awesome!

I found small bug with comment box arrow and fix it:
Before:
<img width="822" alt="2019-03-05 12 00 13" src="https://user-images.githubusercontent.com/3195714/53793707-78948680-3f3f-11e9-835e-767b0327c824.png">
After:
<img width="862" alt="2019-03-05 12 00 21" src="https://user-images.githubusercontent.com/3195714/53800177-2bb7ac80-3f4d-11e9-89aa-8bdfbc4169a0.png">