### PR TITLE
Set default font size for code lines

### DIFF
--- a/src/slide.js
+++ b/src/slide.js
@@ -47,7 +47,8 @@ function Slide({ lines, styles, changes }) {
         margin: 0,
         height: "100%",
         width: "100%",
-        boxSizing: "border-box"
+        boxSizing: "border-box",
+        fontSize: 16
       }}
     >
       <Scroller


### PR DESCRIPTION
This change fixes line cropping that users may experience if they set custom font size in the browser settings

---

What it looks like now:
![Screen Shot 2019-10-25 at 13 42 11](https://user-images.githubusercontent.com/5347023/67566016-6dd96c80-f72f-11e9-9669-69ea17c290d5.png)

The settings in chrome that I have (and that many other people may have):
![Screen Shot 2019-10-25 at 13 42 33](https://user-images.githubusercontent.com/5347023/67566031-77fb6b00-f72f-11e9-9c06-64d2000d2874.png)

What it looks like after the fix:

![Screen Shot 2019-10-25 at 13 44 18](https://user-images.githubusercontent.com/5347023/67566061-88abe100-f72f-11e9-8651-f6d48bf26ec4.png)

### Why this fix is okay for a11y:
I want to emphasize that this is a quick fix that should ideally be temporary. It's best to later change the hardcoded `height: 15px` values to something that respects the current `rem` size.

At the same time, this quick fix is a good solution because you no longer see cropped text (which is hard to read by itself) and also if someone wishes to make their text larger, the zoom-in combo <kbd>command</kbd>+<kbd>+</kbd> still works.