### PR TITLE
Check file is belong to repository

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-
 const runServer = require("./server");
 const fs = require("fs");
+const execa = require("execa");
 
 let path = process.argv[2] || "./.";
 
@@ -18,4 +18,9 @@ if (!fs.existsSync(path)) {
   process.exit();
 }
 
-runServer(path);
+execa("git", ["rev-parse", "--is-inside-work-tree"])
+  .then(() => runServer(path))
+  .catch(() => {
+    console.log(`Git repository not found: ${path}`);
+    process.exit();
+  })


### PR DESCRIPTION
If I try to run git-history in folder outside of repository then git-history run server and throw exception.
 
```sh
$ git-file-history .
Running at http://localhost:5000
Server error { Error: Command failed: git log --max-count=10 --pretty=format:{"hash":"%h","author":{"login":"%aN"},"date":"%ad"}, --date=iso HEAD -- .
fatal: Not a git repository (or any parent up to mount point /home/misha)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).


    at makeError (/usr/lib/node_modules/git-file-history/node_modules/execa/index.js:174:9)
    at Promise.all.then.arr (/usr/lib/node_modules/git-file-history/node_modules/execa/index.js:278:16)
    at process._tickCallback (internal/process/next_tick.js:68:7)
  code: 128,
  stdout: '',
  stderr:
   'fatal: Not a git repository (or any parent up to mount point /home/misha)\nStopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).\n',
  failed: true,
  signal: null,
  cmd:
   'git log --max-count=10 --pretty=format:{"hash":"%h","author":{"login":"%aN"},"date":"%ad"}, --date=iso HEAD -- .',
  timedOut: false,
  killed: false }
```
I propose to check is command running inside folder that belong to repository by `git rev-parse --is-inside-work-tree` before running server