### PR TITLE
Add space before Twitter link

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -16,8 +16,7 @@ export default function App() {
         <footer>
           <a href="https://github.com/pomber/git-history">Git History</a>
           <br />
-          by
-          <a href="https://twitter.com/pomber">@pomber</a>
+          by <a href="https://twitter.com/pomber">@pomber</a>
         </footer>
       </React.Fragment>
     );


### PR DESCRIPTION
Currently in the footer, "by" and "@pomber" don't have any whitespace between them.

This commit shifts the hyperlink up a line so the whitespace between is respected (also making it consistent with [the same text in src/landing.js](https://github.com/pomber/git-history/blob/651dd002e82a60e87ad685f5400b28dff4ed4f46/src/landing.js#L108)).