### PR TITLE
fix the problem of extension Broken on WSL2

### DIFF
--- a/vscode-ext/extension.js
+++ b/vscode-ext/extension.js
@@ -52,11 +52,7 @@ function activate(context) {
           )
           .replace(
             "<head>",
-            `<head><base href="${vscode.Uri.file(
-              path.join(context.extensionPath, "site")
-            ).with({
-              scheme: "vscode-resource"
-            })}/"/>`
+            `<head><base href="${panel.webview.asWebviewUri(vscode.Uri.file(path.join(context.extensionPath,'site')))}/"/>`
           );
 
         panel.webview.html = newIndex;


### PR DESCRIPTION
Use Webview.asWebviewUri to ensure that resources are accessible in both the host environment and the wsl environment.

related issue: https://github.com/pomber/git-history/issues/196